### PR TITLE
feat: register build processing service

### DIFF
--- a/.github/ISSUE_TEMPLATE/cross-service-feature.yml
+++ b/.github/ISSUE_TEMPLATE/cross-service-feature.yml
@@ -34,6 +34,7 @@ body:
       options:
         - label: "scry-ops"
         - label: "upload-service"
+        - label: "build-processing"
         - label: "cdn-service"
         - label: "dashboard"
         - label: "scry-node"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Each label maps to a service repo. Adding a label to an issue tells the workflow
 |-------|-----------|-------------|
 | `scry-ops` | epinnock/scry-ops | Orchestrator workflows, plans, and scripts |
 | `upload-service` | epinnock/scry-storybook-upload-service | Backend API for Storybook uploads |
+| `build-processing` | epinnock/scry-build-processing-service | Async build processing pipeline (LOR, embeddings, vector DB) |
 | `cdn-service` | epinnock/scry-cdn-service | CDN for serving deployed Storybooks |
 | `dashboard` | epinnock/scry-developer-dashboard | Web dashboard for project management |
 | `scry-node` | epinnock/scry-node | CLI tool for deploying Storybooks |
@@ -78,6 +79,7 @@ Each label maps to a service repo. Adding a label to an issue tells the workflow
 When you label an issue with a downstream service, the workflow automatically adds its upstream service dependencies from `repo-map.yml` (`depends_on`). This ensures the selected agent always has the context of shared contracts.
 
 - `scry-node` → auto-adds `upload-service`
+- `build-processing` → auto-adds `upload-service`
 - `cdn-service` → auto-adds `upload-service`
 - `dashboard` → auto-adds `upload-service`
 


### PR DESCRIPTION
## Summary
- Register `scry-build-processing-service` across all scry-ops automation
- Add `milvus` and `cloudflare-queues` to infrastructure registry
- Update data flow diagram to include async processing pipeline

## Changes
- `repo-map.yml` — Add service entry with label `build-processing`, plus `milvus` and `cloudflare-queues` infrastructure
- `CLAUDE.md` — Add service section, update data flow diagram, update dependency order
- `.github/ISSUE_TEMPLATE/cross-service-feature.yml` — Add `build-processing` to affected services checkbox
- `README.md` — Add `build-processing` to service labels table and dependency auto-labeling docs

## Test plan
- [ ] `sync-service-metadata.yml` triggers on merge and creates the `build-processing` label
- [ ] GitHub Project "Service" field gets `build-processing` option
- [ ] Cross-service feature issue template shows `build-processing` checkbox
- [ ] Dependency auto-labeling: issues labeled `build-processing` get `upload-service` auto-added

### Related PRs
- epinnock/scry-build-processing-service#1 — new service implementation
- epinnock/scry-storybook-upload-service#16 — queue producer binding

🤖 Generated with [Claude Code](https://claude.com/claude-code)