### PR TITLE
feat: upgrade default Claude model to Opus 4.6

### DIFF
--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -29,7 +29,7 @@ jobs:
       PROJECT_NUMBER: "1"  # Update after creating the project
       PROJECT_OWNER: "epinnock"
       DEFAULT_CODEX_MODEL: "codex-5.3"
-      DEFAULT_CLAUDE_MODEL: "claude-sonnet-4-5-20250929"
+      DEFAULT_CLAUDE_MODEL: "claude-opus-4-6"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Upgrades the default Claude model in the AI Agent workflow from `claude-sonnet-4-5-20250929` to `claude-opus-4-6`

## Test plan
- [ ] Trigger the claude-agent workflow and verify it uses Opus 4.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)