### PR TITLE
fix: use correct claude-code-action inputs for model and permissions

### DIFF
--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -234,9 +234,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: ${{ env.DEFAULT_CLAUDE_MODEL }}
-          allowed_tools: "Edit,MultiEdit,Glob,Grep,LS,Read,Write,Bash"
+          additional_permissions: "Edit,MultiEdit,Glob,Grep,LS,Read,Write,Bash"
           claude_args: |
+            --model ${{ env.DEFAULT_CLAUDE_MODEL }}
             ${{ steps.dirs.outputs.add_dirs }}
             --max-turns 50
 


### PR DESCRIPTION
## Summary
- Removes invalid `model` input (not a valid action input), passes `--model` via `claude_args` instead so Opus 4.6 is actually used
- Renames `allowed_tools` to `additional_permissions` (the correct input name)

Fixes the warnings from previous runs:
```
Warning: Unexpected input(s) 'model', 'allowed_tools'
```

## Test plan
- [ ] Trigger the claude-agent workflow and verify the init log shows `"model": "claude-opus-4-6"`
- [ ] Verify no unexpected input warnings in the workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)