### PR TITLE
docs: add screenshot metadata zip discovery plan

### DIFF
--- a/plans/screenshot-metadata-zip/00-current-state.md
+++ b/plans/screenshot-metadata-zip/00-current-state.md
@@ -1,0 +1,188 @@
+# Screenshot Metadata ZIP — Current State Analysis
+
+This document maps the current state of how screenshot/metadata ZIPs flow through the Scry platform, identifying where they are generated, stored, and consumed.
+
+---
+
+## Overview
+
+The Scry platform has a **search indexing pipeline** that requires per-story screenshots paired with metadata. This pipeline lives in `scry-build-processing-service`. However, the generation of these screenshots and metadata happens **outside** the current automated deploy flow — creating a gap between what the build-processing service expects and what the upload pipeline currently provides.
+
+---
+
+## Service-by-Service Current State
+
+### scry-node (CLI Deployer)
+
+**What it does today:**
+- Runs `scry deploy` to upload a pre-built Storybook to the upload service
+- Uses `storycap` (shelled out via `execSync`) to capture screenshots of stories
+- Screenshots are saved locally to `__screenshots__/` directory
+- Uploads the **Storybook build ZIP** (compiled static HTML/JS/CSS) to the upload service
+- Optionally uploads a coverage report JSON
+
+**What it does NOT do:**
+- Does not generate a `metadata.json` file pairing stories to screenshots
+- Does not create a ZIP combining screenshots + metadata
+- Does not upload screenshots to the upload service or R2
+- Screenshots captured by storycap are used locally only (or discarded)
+
+**Relevant files:**
+- `scry-node/lib/screencap.js` — storycap invocation
+- `scry-node/bin/cli.js` — CLI commands (deploy, analyze)
+
+---
+
+### scry-storybook-upload-service
+
+**What it does today:**
+- Receives Storybook build ZIPs via `POST /upload/:project/:version`
+- Stores ZIP in R2 at: `{project}/{version}/storybook.zip`
+- Optionally receives coverage report JSON (multipart or separate endpoint)
+- Stores coverage at: `{project}/{version}/coverage-report.json`
+- Creates Firestore build records with auto-incrementing buildNumber
+- Provides presigned URLs for direct R2 uploads
+
+**What it does NOT do:**
+- Does not receive or store screenshot ZIPs
+- Does not generate metadata.json or screenshots
+- Does not publish queue messages to trigger build-processing-service
+  - **This is a known gap** — the architecture diagram shows queue integration but the code has no queue publisher implementation
+
+**R2 storage pattern (current):**
+```
+{project}/{version}/storybook.zip
+{project}/{version}/coverage-report.json  (optional)
+```
+
+**Key observation:** The upload service has **no awareness** of the build-processing pipeline. There is no queue binding in `wrangler.toml` and no message publishing code.
+
+---
+
+### scry-build-processing-service
+
+**What it expects:**
+- A Cloudflare Queue message containing:
+  ```json
+  {
+    "projectId": "my-project",
+    "versionId": "v1.0.0",
+    "buildId": "abc123",
+    "zipKey": "my-project/v1.0.0/builds/5/storybook.zip",
+    "timestamp": 1700000000000
+  }
+  ```
+- The `zipKey` points to a ZIP in R2 with this structure:
+  ```
+  screenshots.zip (or storybook.zip)
+  ├── metadata.json
+  └── images/
+      ├── Button-Primary.png
+      ├── Button-Secondary.png
+      └── Card-Default.png
+  ```
+
+**metadata.json format expected:**
+```json
+[
+  {
+    "filepath": "stories/Button.stories.ts",
+    "componentName": "Button",
+    "testName": "Primary",
+    "storyTitle": "Example/Button",
+    "screenshotPath": "images/Button-Primary.png",
+    "location": { "startLine": 10, "endLine": 20 }
+  }
+]
+```
+
+**Processing pipeline:**
+1. Extract ZIP from R2 → parse metadata.json + collect screenshot images
+2. Match each story's `screenshotPath` to actual image bytes in ZIP
+3. Send screenshots to OpenAI Vision API (gpt-5-mini) for LLM inspection
+4. Generate searchable text from inspection results
+5. Generate image + text embeddings via Jina AI
+6. Insert vectors into Milvus for search indexing
+7. Update Firestore with processing status
+
+**Key observation:** This service is fully implemented and tested, but has **no upstream producer** sending it queue messages or creating the expected ZIP format.
+
+---
+
+### scry-cdn-service
+
+**What it does today:**
+- Serves files from Storybook ZIPs stored in R2
+- Uses partial ZIP extraction (range requests) for efficient serving
+- Caches central directory metadata in KV (24hr TTL)
+- Handles coverage-report.json as a special case
+
+**Relevance to this feature:**
+- If screenshots are stored as a separate ZIP in R2, the CDN could potentially serve them
+- Currently only reads from `{project}/{version}/storybook.zip` path pattern
+- No special handling for screenshot or metadata files
+
+---
+
+### scry-sbcov (Coverage Tool)
+
+**What it does today:**
+- Analyzes Storybook stories for coverage metrics
+- Uses Playwright to execute stories and verify rendering
+- Can capture screenshots on failure (verification screenshots)
+- Generates coverage reports (JSON)
+
+**Relevant capabilities:**
+- Has a working Playwright browser session for visiting Storybook stories
+- Already navigates to each story's iframe URL
+- Can capture screenshots (currently only on verification failure)
+- Knows story metadata: filepath, componentName, testName, storyTitle
+
+**Key observation:** scry-sbcov is the most natural place to generate the metadata.json + screenshots ZIP, since it already visits every story with a browser session.
+
+---
+
+## R2 Storage Path Discrepancy
+
+There is a mismatch between the storage patterns used by different services:
+
+| Service | R2 Path Pattern |
+|---------|----------------|
+| Upload Service (writes) | `{project}/{version}/storybook.zip` |
+| Build Processing (reads) | `{project}/{version}/builds/{buildNumber}/storybook.zip` |
+| CDN Service (reads) | `{project}/{version}/storybook.zip` |
+| CLAUDE.md (documented) | `{project}/{version}/builds/{buildNumber}/storybook.zip` |
+
+The build-processing service's `zipKey` comes from the queue message, so it can point anywhere. But the documented convention in CLAUDE.md includes `builds/{buildNumber}/` which the upload service does not currently use.
+
+---
+
+## Data Flow Diagram (Current)
+
+```
+scry-node (CLI)
+  ├── Captures screenshots locally (storycap) → __screenshots__/ [NOT UPLOADED]
+  ├── Uploads Storybook ZIP → upload-service → R2 (storybook.zip)
+  └── Optionally uploads coverage JSON → upload-service → R2 (coverage-report.json)
+
+scry-sbcov (Coverage)
+  └── Generates coverage report JSON [uploaded separately or via scry-node]
+
+scry-build-processing-service
+  └── Expects queue message + metadata ZIP in R2 [NO PRODUCER EXISTS]
+
+scry-cdn-service
+  └── Reads storybook.zip from R2 and serves files [WORKING]
+```
+
+---
+
+## Summary of Gaps
+
+| Gap | Description | Impact |
+|-----|-------------|--------|
+| **No metadata.json generation** | No service currently generates the `metadata.json` file that pairs stories to screenshot paths | Build-processing pipeline cannot run |
+| **No screenshot ZIP upload** | Screenshots captured by scry-node/storycap are local-only, never uploaded | Build-processing pipeline has no input |
+| **No queue integration** | Upload service doesn't publish queue messages after upload | Build-processing pipeline never triggered |
+| **R2 path mismatch** | Upload service and build-processing service use different R2 path conventions | Would cause lookup failures even if queue existed |
+| **Separate tools** | Screenshots (storycap/scry-node) and metadata (scry-sbcov) are generated by different tools in different browser sessions | Inefficient; story-capture unification plan addresses this |

--- a/plans/screenshot-metadata-zip/01-gap-analysis.md
+++ b/plans/screenshot-metadata-zip/01-gap-analysis.md
@@ -1,0 +1,177 @@
+# Screenshot Metadata ZIP — Gap Analysis
+
+This document details the specific gaps between what exists today and what is needed for the build-processing pipeline to function end-to-end.
+
+---
+
+## Gap 1: No Metadata ZIP Generation
+
+### What's needed
+A ZIP file containing:
+```
+metadata-screenshots.zip
+├── metadata.json          # Array of story objects with screenshot references
+└── images/
+    ├── Button-Primary.png
+    ├── Card-Default.png
+    └── ...
+```
+
+### metadata.json schema (required by build-processing-service)
+```json
+[
+  {
+    "filepath": "stories/Button.stories.ts",
+    "componentName": "Button",
+    "testName": "Primary",
+    "storyTitle": "Example/Button",
+    "screenshotPath": "images/Button-Primary.png",
+    "location": { "startLine": 10, "endLine": 20 }
+  }
+]
+```
+
+### Where it could be generated
+| Source | Knows stories? | Has browser? | Knows file paths? |
+|--------|---------------|-------------|-------------------|
+| scry-node (storycap) | Partial — fetches story list | Yes (Puppeteer) | No — only story IDs |
+| scry-sbcov | Yes — full story analysis | Yes (Playwright) | Yes — parses .stories.ts files |
+| GitHub Actions step | Depends on tool used | Can install browsers | Depends on tool used |
+
+### Current state
+- **scry-node**: Captures screenshots via storycap but discards metadata mapping. Only knows storyId, not filepath/componentName.
+- **scry-sbcov**: Has all the metadata (filepath, componentName, testName, storyTitle, location) from its story file parser. Can capture screenshots via Playwright. Does not currently bundle them into a ZIP.
+
+---
+
+## Gap 2: No Queue Integration Between Upload and Build-Processing
+
+### What's needed
+After a Storybook upload completes, the upload service should publish a message to a Cloudflare Queue that triggers the build-processing pipeline.
+
+### Queue message format (build-processing-service expects)
+```typescript
+interface QueueMessage {
+  projectId: string;
+  versionId: string;
+  buildId: string;
+  zipKey: string;       // R2 path to the metadata+screenshots ZIP
+  timestamp: number;
+}
+```
+
+### Current state
+- **upload-service**: No queue binding in `wrangler.toml`, no queue publishing code
+- **build-processing-service**: Queue consumer is fully implemented with:
+  - Queue name: `scry-build-processing`
+  - Dead letter queue: `scry-build-processing-dlq`
+  - Max batch size: 1
+  - Max retries: 3
+  - Max concurrency: 5
+
+### What's missing in upload-service
+1. Queue producer binding in `wrangler.toml`:
+   ```toml
+   [[queues.producers]]
+   queue = "scry-build-processing"
+   binding = "BUILD_PROCESSING_QUEUE"
+   ```
+2. Code to publish message after successful upload
+3. The `zipKey` in the message needs to reference the metadata ZIP, not the storybook ZIP
+
+---
+
+## Gap 3: R2 Storage Path Convention Mismatch
+
+### What's needed
+A consistent R2 path convention used by all services.
+
+### Current inconsistency
+| Source | Pattern |
+|--------|---------|
+| CLAUDE.md documentation | `{project}/{version}/builds/{buildNumber}/storybook.zip` |
+| Upload service (actual code) | `{project}/{version}/storybook.zip` |
+| CDN service (actual code) | `{project}/{version}/storybook.zip` |
+| Build-processing (queue message) | `zipKey` field — whatever is sent |
+
+### Options
+1. **Keep current path** (`{project}/{version}/storybook.zip`) — simpler, matches upload + CDN
+2. **Add buildNumber** (`{project}/{version}/builds/{buildNumber}/storybook.zip`) — matches CLAUDE.md docs, supports build history
+3. **Separate path for metadata ZIP** — e.g., `{project}/{version}/builds/{buildNumber}/metadata-screenshots.zip`
+
+### Recommendation
+Use the `builds/{buildNumber}/` prefix for the metadata-screenshots ZIP since it's per-build (not per-version), while keeping `storybook.zip` at the version level since Storybook builds overwrite per version.
+
+```
+{project}/{version}/storybook.zip                                    # Storybook build (served by CDN)
+{project}/{version}/builds/{buildNumber}/metadata-screenshots.zip    # Screenshots + metadata (processed by build-processing)
+{project}/{version}/coverage-report.json                             # Coverage data
+```
+
+---
+
+## Gap 4: Two Separate Screenshot Artifacts
+
+### What's needed
+The metadata-screenshots ZIP for build-processing is **different** from the Storybook build ZIP:
+
+| Artifact | Content | Consumer | Purpose |
+|----------|---------|----------|---------|
+| `storybook.zip` | Compiled Storybook (HTML/JS/CSS) | CDN service | Serve the Storybook UI |
+| `metadata-screenshots.zip` | Screenshots + metadata.json | Build-processing service | Search indexing pipeline |
+
+### Current state
+- Only `storybook.zip` is generated and uploaded
+- `metadata-screenshots.zip` does not exist anywhere in the pipeline
+- These are fundamentally different artifacts that cannot be combined:
+  - Storybook ZIP: pre-built static site, no screenshots
+  - Metadata ZIP: raw screenshots + story metadata, no HTML/JS/CSS
+
+### Implication
+The deploy flow needs to produce **two artifacts**, not one. This affects:
+- scry-node CLI (or GitHub Actions) — must generate both
+- Upload service — must accept and store both
+- Queue message — must reference the metadata ZIP specifically
+
+---
+
+## Gap 5: Story Metadata Not Available at Deploy Time
+
+### What's needed
+The `metadata.json` requires these fields per story:
+- `filepath` — e.g., `stories/Button.stories.ts`
+- `componentName` — e.g., `Button`
+- `testName` — e.g., `Primary`
+- `storyTitle` — e.g., `Example/Button`
+- `screenshotPath` — e.g., `images/Button-Primary.png`
+- `location` (optional) — `{ startLine, endLine }`
+
+### What each tool currently knows
+
+| Field | scry-node (storycap) | scry-sbcov | Storybook index.json |
+|-------|---------------------|-----------|---------------------|
+| filepath | No | Yes (AST parser) | No |
+| componentName | No | Yes (from meta) | Partial (title) |
+| testName | No | Yes (from exports) | Yes (name) |
+| storyTitle | Partial (from ID) | Yes | Yes (title) |
+| screenshotPath | Yes (output path) | Can generate | No |
+| location | No | Yes (AST) | No |
+
+### Implication
+- scry-sbcov is the only tool that has **all** the required metadata fields
+- scry-node would need to either:
+  1. Depend on scry-sbcov to generate metadata
+  2. Parse story files itself (duplicating scry-sbcov logic)
+  3. Use only what's available from Storybook's `index.json` (missing filepath, location)
+
+---
+
+## Priority Order
+
+| Priority | Gap | Reason |
+|----------|-----|--------|
+| **P0** | Metadata ZIP generation | Without this, build-processing has no input |
+| **P0** | Queue integration | Without this, build-processing is never triggered |
+| **P1** | R2 path convention | Needs alignment before implementing |
+| **P1** | Two-artifact deploy flow | Core architectural decision |
+| **P2** | Story metadata availability | Determines which tool generates the ZIP |

--- a/plans/screenshot-metadata-zip/02-options.md
+++ b/plans/screenshot-metadata-zip/02-options.md
@@ -1,0 +1,282 @@
+# Screenshot Metadata ZIP — Options Analysis
+
+This document presents the possible approaches for generating and delivering the metadata-screenshots ZIP to the build-processing pipeline.
+
+---
+
+## Option A: Generate in scry-sbcov, Upload via scry-node
+
+### Description
+Extend scry-sbcov to produce a `metadata-screenshots.zip` as part of its analysis run. scry-node would invoke scry-sbcov during `scry deploy` and upload the resulting ZIP alongside the Storybook build.
+
+### How it works
+1. **scry-sbcov** adds a `--capture-screenshots` flag (or `--output-zip`)
+2. During story execution, captures a screenshot of each story
+3. Generates `metadata.json` with full story metadata (filepath, componentName, testName, storyTitle, screenshotPath, location)
+4. Bundles into `metadata-screenshots.zip`
+5. **scry-node** runs scry-sbcov as part of `scry deploy`
+6. Uploads the ZIP to upload-service (new endpoint or presigned URL)
+7. Upload-service stores in R2 and publishes queue message
+
+### Changes required
+| Service | Changes |
+|---------|---------|
+| scry-sbcov | Add screenshot capture during execution, ZIP bundling, new CLI flag |
+| scry-node | Add scry-sbcov invocation during deploy, upload metadata ZIP |
+| upload-service | New endpoint or field for metadata ZIP, queue publisher |
+| build-processing | None — already handles this format |
+| cdn-service | None |
+
+### Pros
+- scry-sbcov already has all the metadata (filepath, componentName, location, etc.)
+- scry-sbcov already uses Playwright and visits every story
+- Single browser session for verification + screenshots (efficient)
+- Aligns with the planned "unified story capture" feature
+- metadata.json has the richest data possible
+
+### Cons
+- Requires Playwright/browser at deploy time (CI needs browser installed)
+- Adds time to deploy (screenshot capture for all stories)
+- scry-sbcov is a dev dependency, adds weight to deploy step
+- Couples deploy to coverage analysis tool
+
+### Complexity: Medium
+
+---
+
+## Option B: Generate in scry-node Using Storybook index.json
+
+### Description
+scry-node captures screenshots (current storycap behavior) and generates a metadata.json from Storybook's built-in `index.json`, without needing scry-sbcov.
+
+### How it works
+1. **scry-node** fetches `{storybookUrl}/index.json` (or `stories.json`)
+2. Extracts story metadata: id, title, name, importPath
+3. Captures screenshots for each story (already does this via storycap)
+4. Generates `metadata.json` mapping story IDs to screenshot paths
+5. Bundles into `metadata-screenshots.zip`
+6. Uploads alongside the Storybook build
+
+### metadata.json (limited fields)
+```json
+[
+  {
+    "filepath": "",
+    "componentName": "Button",
+    "testName": "Primary",
+    "storyTitle": "Example/Button",
+    "screenshotPath": "images/example-button--primary.png"
+  }
+]
+```
+
+### Changes required
+| Service | Changes |
+|---------|---------|
+| scry-node | Generate metadata.json from index.json, bundle ZIP, upload |
+| upload-service | New endpoint or field for metadata ZIP, queue publisher |
+| build-processing | None |
+| cdn-service | None |
+| scry-sbcov | None |
+
+### Pros
+- Self-contained in scry-node (no scry-sbcov dependency)
+- Already captures screenshots via storycap
+- Simpler deployment dependency chain
+- Storybook's index.json is always available for built Storybooks
+
+### Cons
+- Missing key metadata: `filepath`, `location` (not in index.json)
+- `componentName` must be inferred from title (less accurate)
+- Relies on storycap (planned for replacement per story-capture plan)
+- Two browser processes if also running scry-sbcov for coverage
+
+### Complexity: Low
+
+---
+
+## Option C: Dedicated GitHub Actions Step
+
+### Description
+Add a GitHub Actions step (or reusable workflow) that runs after the Storybook build, captures screenshots, generates metadata, bundles the ZIP, and uploads it — independent of scry-node.
+
+### How it works
+1. **GitHub Action** (new or reusable workflow) runs after Storybook build
+2. Starts a local Storybook server from the build output
+3. Uses Playwright/Puppeteer to capture screenshots of each story
+4. Generates metadata.json using Storybook's index.json + optional scry-sbcov data
+5. Bundles into metadata-screenshots.zip
+6. Uploads to upload-service via API call (or presigned URL direct to R2)
+7. Upload-service publishes queue message
+
+### GitHub Actions workflow snippet
+```yaml
+- name: Build Storybook
+  run: npm run build-storybook
+
+- name: Deploy Storybook
+  run: npx scry deploy --storybook-dir ./storybook-static
+
+- name: Generate Search Metadata
+  uses: scrymore/screenshot-metadata-action@v1
+  with:
+    storybook-dir: ./storybook-static
+    output: ./metadata-screenshots.zip
+    upload-url: ${{ secrets.SCRY_UPLOAD_URL }}
+    api-key: ${{ secrets.SCRY_API_KEY }}
+```
+
+### Changes required
+| Service | Changes |
+|---------|---------|
+| scry-ops | New GitHub Action or reusable workflow |
+| upload-service | Accept metadata ZIP upload, queue publisher |
+| build-processing | None |
+| scry-node | None (or minimal — pass through build info) |
+| scry-sbcov | Optional — could be invoked for richer metadata |
+
+### Pros
+- Decoupled from CLI tool — works with any CI system
+- Can run in parallel with deploy (non-blocking)
+- Reusable across different client setups
+- Can use scry-sbcov for rich metadata or index.json for basic metadata
+- Screenshots generated in CI have consistent environment (no local machine variance)
+
+### Cons
+- Additional CI step adds build time
+- Requires browser installation in CI (Playwright setup action)
+- New infrastructure to maintain (GitHub Action)
+- Users must update their CI config
+- More moving parts than integrated approach
+
+### Complexity: Medium-High
+
+---
+
+## Option D: Server-Side Screenshot Generation (Build-Processing Service)
+
+### Description
+Instead of generating screenshots client-side, modify the build-processing service to open the deployed Storybook, capture screenshots itself, and then process them.
+
+### How it works
+1. Upload service receives Storybook ZIP and deploys it (already happens via CDN)
+2. Queue message is sent with the Storybook URL (not a screenshots ZIP)
+3. Build-processing service:
+   a. Fetches story list from deployed Storybook's index.json
+   b. Uses a headless browser service to capture screenshots
+   c. Generates metadata.json
+   d. Processes screenshots through the existing pipeline (LLM, embeddings, vectors)
+
+### Changes required
+| Service | Changes |
+|---------|---------|
+| build-processing | Major rewrite — add browser/screenshot generation, change from ZIP input to URL input |
+| upload-service | Queue publisher (simpler message — just Storybook URL) |
+| scry-node | None |
+| scry-sbcov | None |
+
+### Pros
+- Zero changes to client-side tools (scry-node, GitHub Actions)
+- Centralized — all processing in one place
+- Guaranteed consistency (same browser for all users)
+- Simplest client integration
+
+### Cons
+- **Cloudflare Workers cannot run headless browsers** — would need a separate browser service (e.g., Browserless, Puppeteer on a VM, or Cloudflare Browser Rendering)
+- Significant architectural change to build-processing service
+- Higher operational cost (browser infrastructure)
+- Higher latency (must wait for Storybook to be available via CDN)
+- Missing metadata that only source analysis can provide (filepath, location)
+- Single point of failure for screenshot generation
+
+### Complexity: High
+
+---
+
+## Option E: Hybrid — scry-sbcov Generates ZIP, Uploaded Independently
+
+### Description
+scry-sbcov generates the metadata-screenshots.zip as a standalone command, and the ZIP is uploaded separately from the Storybook deploy — either by the user, by scry-node, or by CI.
+
+### How it works
+1. User runs `npx scry-sbcov analyze --screenshots --output-zip ./metadata-screenshots.zip`
+2. scry-sbcov captures screenshots + generates full metadata
+3. User/CI uploads the ZIP:
+   - Via scry-node: `npx scry upload-metadata ./metadata-screenshots.zip`
+   - Via direct API: `curl -X POST upload-service/upload-metadata`
+   - Via presigned URL
+
+### Changes required
+| Service | Changes |
+|---------|---------|
+| scry-sbcov | Screenshot capture + ZIP bundling (same as Option A) |
+| scry-node | Optional: `upload-metadata` command |
+| upload-service | Metadata ZIP endpoint, queue publisher |
+| build-processing | None |
+
+### Pros
+- Decoupled: generate and upload are separate steps
+- Works with or without scry-node
+- Full metadata from scry-sbcov
+- User controls when screenshots are generated vs. deployed
+
+### Cons
+- Two-step process (generate then upload) vs. integrated deploy
+- User must manage the ZIP file
+- Risk of stale screenshots if not regenerated before deploy
+- More complex user workflow
+
+### Complexity: Medium
+
+---
+
+## Comparison Matrix
+
+| Criteria | A: sbcov+node | B: node only | C: GH Actions | D: Server-side | E: Hybrid |
+|----------|:---:|:---:|:---:|:---:|:---:|
+| Metadata richness | Full | Partial | Configurable | Partial | Full |
+| Client complexity | Medium | Low | Medium | None | Medium |
+| Server changes | Small | Small | Small | Large | Small |
+| Browser dependency at deploy | Yes | Yes (existing) | Yes (CI) | No | Yes (separate) |
+| Aligns with story-capture plan | Yes | No | Partially | No | Yes |
+| Works without scry-sbcov | No | Yes | Yes/No | Yes | No |
+| CI integration effort | Low | Low | Medium | None | Medium |
+| Operational cost | Low | Low | Low | High | Low |
+
+---
+
+## Recommendation
+
+### Short-term: Option B (scry-node with index.json)
+- Fastest to implement
+- Leverages existing storycap screenshot capture
+- Gets the pipeline working with basic metadata
+- No new tool dependencies
+
+### Medium-term: Option A (scry-sbcov + scry-node)
+- Aligns with the planned "unified story capture" service
+- Provides full metadata (filepath, location, componentName)
+- Single browser session for screenshots + verification
+- Replaces storycap dependency (already planned)
+
+### Long-term: Option C (GitHub Actions) as an additional distribution channel
+- Publish a reusable GitHub Action that wraps Option A
+- Provides a standard CI integration path
+- Can run in parallel with deploy for non-blocking indexing
+
+### Not recommended: Option D (server-side)
+- Cloudflare Workers' browser limitations make this impractical without significant infrastructure changes
+- Higher operational cost and complexity
+- Loses source-level metadata
+
+---
+
+## Decision Points
+
+Before implementing, these decisions need to be made:
+
+1. **Which option to start with?** (Recommend: B for quick win, then A)
+2. **Should metadata ZIP upload be part of `POST /upload` or a separate endpoint?**
+3. **Should queue integration be implemented in upload-service or as a separate trigger?**
+4. **What R2 path convention to use for the metadata ZIP?**
+5. **Should screenshot generation be opt-in or default during deploy?**

--- a/plans/screenshot-metadata-zip/03-architecture-diagrams.md
+++ b/plans/screenshot-metadata-zip/03-architecture-diagrams.md
@@ -1,0 +1,338 @@
+# Screenshot Metadata ZIP — Architecture Diagrams
+
+This document contains Mermaid diagrams illustrating the current state, gaps, and proposed solutions.
+
+---
+
+## 1. Current State — Data Flow
+
+```mermaid
+flowchart TD
+    subgraph Client["Client Side (CI / Local)"]
+        SB["Storybook Build<br/>(npm run build-storybook)"]
+        NODE["scry-node CLI<br/>(scry deploy)"]
+        SBCOV["scry-sbcov<br/>(scry-sbcov analyze)"]
+        STORYCAP["storycap<br/>(screenshots)"]
+    end
+
+    subgraph Cloud["Cloud Services"]
+        UPLOAD["Upload Service<br/>(Hono + CF Workers)"]
+        R2["Cloudflare R2<br/>(Object Storage)"]
+        FS["Firestore<br/>(Metadata DB)"]
+        CDN["CDN Service<br/>(Hono + CF Workers)"]
+        BPS["Build Processing Service<br/>(CF Workers + Queue)"]
+        MILVUS["Milvus<br/>(Vector DB)"]
+    end
+
+    SB -->|"storybook-static/"| NODE
+    NODE -->|"storycap"| STORYCAP
+    STORYCAP -->|"__screenshots__/<br/>(LOCAL ONLY)"| STORYCAP
+    NODE -->|"POST /upload<br/>storybook.zip"| UPLOAD
+    NODE -.->|"coverage.json<br/>(optional)"| UPLOAD
+    SBCOV -->|"coverage-report.json<br/>(separate run)"| NODE
+
+    UPLOAD -->|"PUT storybook.zip"| R2
+    UPLOAD -->|"Create build doc"| FS
+    UPLOAD -.->|"PUT coverage-report.json"| R2
+
+    R2 -->|"Range reads"| CDN
+    CDN -->|"Serve files"| USER["End User Browser"]
+
+    R2 -.->|"❌ No queue message<br/>❌ No metadata ZIP"| BPS
+    BPS -.->|"❌ Never triggered"| MILVUS
+
+    style STORYCAP fill:#ff9999,stroke:#cc0000
+    style BPS fill:#ff9999,stroke:#cc0000
+    style MILVUS fill:#ff9999,stroke:#cc0000
+```
+
+**Legend:** Red nodes indicate broken/disconnected parts of the pipeline.
+
+---
+
+## 2. Current State — ZIP Contents Comparison
+
+```mermaid
+graph LR
+    subgraph Current["What Upload Service Receives"]
+        SZ["storybook.zip"]
+        SZ --> HTML["index.html"]
+        SZ --> JS["main.js / iframe.js"]
+        SZ --> CSS["main.css"]
+        SZ --> ASSETS["static/media/*"]
+        SZ --> IDX["index.json<br/>(story manifest)"]
+    end
+
+    subgraph Expected["What Build Processing Expects"]
+        MZ["metadata-screenshots.zip"]
+        MZ --> META["metadata.json"]
+        MZ --> IMG["images/"]
+        IMG --> PNG1["Button-Primary.png"]
+        IMG --> PNG2["Card-Default.png"]
+        IMG --> PNG3["..."]
+    end
+
+    Current -.->|"❌ Different artifacts<br/>Cannot be the same ZIP"| Expected
+
+    style Current fill:#e6f3ff,stroke:#0066cc
+    style Expected fill:#fff3e6,stroke:#cc6600
+```
+
+---
+
+## 3. Proposed Flow — Option A (scry-sbcov + scry-node)
+
+```mermaid
+flowchart TD
+    subgraph Client["Client Side (CI / Local)"]
+        SB["Storybook Build"]
+        NODE["scry-node CLI"]
+        SBCOV["scry-sbcov<br/>(+ screenshot capture)"]
+    end
+
+    subgraph Cloud["Cloud Services"]
+        UPLOAD["Upload Service"]
+        QUEUE["CF Queue<br/>(scry-build-processing)"]
+        R2["Cloudflare R2"]
+        FS["Firestore"]
+        CDN["CDN Service"]
+        BPS["Build Processing Service"]
+        OPENAI["OpenAI Vision"]
+        JINA["Jina AI Embeddings"]
+        MILVUS["Milvus Vector DB"]
+    end
+
+    SB -->|"storybook-static/"| NODE
+    NODE -->|"invoke"| SBCOV
+    SBCOV -->|"1. Visit each story<br/>2. Capture screenshots<br/>3. Generate metadata.json<br/>4. Bundle ZIP"| SBCOV
+    SBCOV -->|"metadata-screenshots.zip"| NODE
+
+    NODE -->|"POST /upload<br/>storybook.zip"| UPLOAD
+    NODE -->|"POST /upload-metadata<br/>metadata-screenshots.zip"| UPLOAD
+
+    UPLOAD -->|"storybook.zip"| R2
+    UPLOAD -->|"metadata-screenshots.zip"| R2
+    UPLOAD -->|"Build record"| FS
+    UPLOAD -->|"Queue message"| QUEUE
+
+    QUEUE -->|"Trigger"| BPS
+    BPS -->|"Fetch ZIP"| R2
+    BPS -->|"Screenshot inspection"| OPENAI
+    BPS -->|"Embeddings"| JINA
+    BPS -->|"Insert vectors"| MILVUS
+    BPS -->|"Update status"| FS
+
+    R2 -->|"Range reads"| CDN
+
+    style SBCOV fill:#99ff99,stroke:#009900
+    style QUEUE fill:#99ff99,stroke:#009900
+    style BPS fill:#99ff99,stroke:#009900
+    style MILVUS fill:#99ff99,stroke:#009900
+```
+
+---
+
+## 4. Proposed Flow — Option B (scry-node with index.json)
+
+```mermaid
+flowchart TD
+    subgraph Client["Client Side (CI / Local)"]
+        SB["Storybook Build"]
+        NODE["scry-node CLI"]
+        STORYCAP["storycap<br/>(existing)"]
+    end
+
+    subgraph Cloud["Cloud Services"]
+        UPLOAD["Upload Service"]
+        QUEUE["CF Queue"]
+        R2["Cloudflare R2"]
+        FS["Firestore"]
+        BPS["Build Processing Service"]
+        MILVUS["Milvus Vector DB"]
+    end
+
+    SB -->|"storybook-static/"| NODE
+    NODE -->|"1. Read index.json<br/>2. Run storycap<br/>3. Generate metadata.json<br/>4. Bundle ZIP"| NODE
+    NODE -->|"storycap"| STORYCAP
+    STORYCAP -->|"screenshots"| NODE
+
+    NODE -->|"storybook.zip"| UPLOAD
+    NODE -->|"metadata-screenshots.zip"| UPLOAD
+
+    UPLOAD -->|"Store both ZIPs"| R2
+    UPLOAD -->|"Queue message"| QUEUE
+    UPLOAD -->|"Build record"| FS
+
+    QUEUE --> BPS
+    BPS -->|"Process"| MILVUS
+
+    style NODE fill:#99ff99,stroke:#009900
+    style QUEUE fill:#99ff99,stroke:#009900
+```
+
+---
+
+## 5. Proposed Flow — Option C (GitHub Actions)
+
+```mermaid
+flowchart TD
+    subgraph GHA["GitHub Actions Workflow"]
+        BUILD["npm run build-storybook"]
+        DEPLOY["scry deploy<br/>(storybook.zip)"]
+        SCREEN["Screenshot Metadata Action<br/>(new)"]
+    end
+
+    subgraph Cloud["Cloud Services"]
+        UPLOAD["Upload Service"]
+        QUEUE["CF Queue"]
+        R2["Cloudflare R2"]
+        BPS["Build Processing"]
+        MILVUS["Milvus"]
+    end
+
+    BUILD -->|"storybook-static/"| DEPLOY
+    BUILD -->|"storybook-static/"| SCREEN
+    DEPLOY -->|"storybook.zip"| UPLOAD
+    SCREEN -->|"1. Start local server<br/>2. Playwright screenshots<br/>3. Generate metadata<br/>4. Bundle ZIP"| SCREEN
+    SCREEN -->|"metadata-screenshots.zip"| UPLOAD
+
+    UPLOAD --> R2
+    UPLOAD --> QUEUE
+    QUEUE --> BPS
+    BPS --> MILVUS
+
+    DEPLOY -.->|"parallel"| SCREEN
+
+    style SCREEN fill:#99ff99,stroke:#009900
+    style QUEUE fill:#99ff99,stroke:#009900
+```
+
+---
+
+## 6. R2 Storage Layout — Proposed
+
+```mermaid
+graph TD
+    subgraph R2["Cloudflare R2 Bucket"]
+        subgraph Project["my-project/"]
+            subgraph Version["v1.0.0/"]
+                SZ["storybook.zip<br/>(Storybook build — served by CDN)"]
+                CR["coverage-report.json<br/>(Coverage data — optional)"]
+                subgraph Builds["builds/"]
+                    subgraph B1["1/"]
+                        MZ1["metadata-screenshots.zip<br/>(Screenshots + metadata)"]
+                    end
+                    subgraph B2["2/"]
+                        MZ2["metadata-screenshots.zip"]
+                    end
+                end
+            end
+        end
+    end
+
+    style SZ fill:#e6f3ff,stroke:#0066cc
+    style CR fill:#e6ffe6,stroke:#009900
+    style MZ1 fill:#fff3e6,stroke:#cc6600
+    style MZ2 fill:#fff3e6,stroke:#cc6600
+```
+
+---
+
+## 7. Queue Message Flow — Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant CLI as scry-node CLI
+    participant US as Upload Service
+    participant R2 as Cloudflare R2
+    participant FS as Firestore
+    participant Q as CF Queue
+    participant BPS as Build Processing
+    participant AI as OpenAI + Jina
+    participant MV as Milvus
+
+    CLI->>US: POST /upload (storybook.zip)
+    US->>R2: PUT {project}/{version}/storybook.zip
+    US->>FS: Create build record (buildNumber: N)
+    US-->>CLI: 201 { buildId, buildNumber }
+
+    CLI->>US: POST /upload-metadata (metadata-screenshots.zip)
+    US->>R2: PUT {project}/{version}/builds/N/metadata-screenshots.zip
+    US->>Q: Publish { projectId, versionId, buildId, zipKey }
+    US-->>CLI: 201 { success }
+
+    Q->>BPS: Deliver message
+    BPS->>R2: GET metadata-screenshots.zip
+    BPS->>BPS: Extract ZIP (metadata.json + images)
+    BPS->>BPS: Parse metadata, match screenshots
+    BPS->>FS: Update status: processing
+
+    loop For each batch of 5 stories
+        BPS->>AI: OpenAI Vision (screenshots)
+        AI-->>BPS: Component descriptions + tags
+    end
+
+    loop For each batch of 10
+        BPS->>AI: Jina AI (image embeddings)
+        AI-->>BPS: Image vectors
+        BPS->>AI: Jina AI (text embeddings)
+        AI-->>BPS: Text vectors
+    end
+
+    BPS->>MV: Insert vectors (batches of 50)
+    BPS->>FS: Update status: completed
+```
+
+---
+
+## 8. Decision Tree — Which Option to Choose
+
+```mermaid
+flowchart TD
+    START["Need screenshot<br/>metadata ZIP"] --> Q1{"Need rich metadata?<br/>(filepath, location)"}
+
+    Q1 -->|"Yes"| Q2{"scry-sbcov already<br/>in deploy workflow?"}
+    Q1 -->|"No, basic is fine"| OPT_B["Option B<br/>scry-node + index.json"]
+
+    Q2 -->|"Yes"| OPT_A["Option A<br/>scry-sbcov + scry-node"]
+    Q2 -->|"No"| Q3{"Want CI integration?"}
+
+    Q3 -->|"Yes"| OPT_C["Option C<br/>GitHub Actions"]
+    Q3 -->|"No"| OPT_E["Option E<br/>Hybrid (standalone sbcov)"]
+
+    OPT_B --> IMPL["Implement queue<br/>integration in<br/>upload-service"]
+    OPT_A --> IMPL
+    OPT_C --> IMPL
+    OPT_E --> IMPL
+
+    style OPT_A fill:#99ff99,stroke:#009900
+    style OPT_B fill:#ffffcc,stroke:#cccc00
+    style OPT_C fill:#e6f3ff,stroke:#0066cc
+    style OPT_E fill:#ffe6ff,stroke:#cc00cc
+    style IMPL fill:#ff9999,stroke:#cc0000
+```
+
+---
+
+## 9. Implementation Phases
+
+```mermaid
+gantt
+    title Screenshot Metadata ZIP — Implementation Phases
+    dateFormat YYYY-MM-DD
+    axisFormat %b %d
+
+    section Phase 1 (Foundation)
+    Upload service queue integration        :p1a, 2026-03-01, 5d
+    R2 path convention alignment            :p1b, 2026-03-01, 3d
+    Upload service metadata ZIP endpoint    :p1c, after p1b, 4d
+
+    section Phase 2 (Generation)
+    Option B: scry-node metadata gen        :p2a, after p1c, 5d
+    OR Option A: scry-sbcov screenshots     :p2b, after p1c, 7d
+
+    section Phase 3 (Integration)
+    End-to-end testing                      :p3a, after p2a, 3d
+    GitHub Actions workflow template        :p3b, after p3a, 3d
+    Documentation                           :p3c, after p3a, 2d
+```

--- a/plans/screenshot-metadata-zip/README.md
+++ b/plans/screenshot-metadata-zip/README.md
@@ -1,0 +1,59 @@
+# Screenshot Metadata ZIP — Discovery Plan
+
+**Issue:** #27
+**Date:** 2026-02-23
+**Status:** Discovery complete, pending decision
+
+---
+
+## Summary
+
+The `scry-build-processing-service` expects a ZIP containing `metadata.json` + story screenshots to power the search indexing pipeline (OpenAI Vision inspection → Jina embeddings → Milvus vectors). However, **no service currently generates or uploads this ZIP**.
+
+The Storybook build ZIP uploaded by `scry-node` is a compiled static site (HTML/JS/CSS) — a fundamentally different artifact from what build-processing needs.
+
+---
+
+## Documents
+
+| File | Description |
+|------|-------------|
+| [00-current-state.md](./00-current-state.md) | Detailed analysis of how each service currently handles ZIPs, metadata, and screenshots |
+| [01-gap-analysis.md](./01-gap-analysis.md) | Five specific gaps identified between current state and required pipeline |
+| [02-options.md](./02-options.md) | Five implementation options with pros/cons, complexity, and comparison matrix |
+| [03-architecture-diagrams.md](./03-architecture-diagrams.md) | Mermaid diagrams: current state, proposed flows, R2 layout, sequence diagrams, decision tree |
+
+---
+
+## Key Findings
+
+1. **Two different ZIPs needed**: The Storybook build ZIP (for CDN) and the metadata-screenshots ZIP (for search indexing) are separate artifacts
+2. **Queue integration missing**: Upload service has no code to publish queue messages to trigger build-processing
+3. **R2 path mismatch**: Upload service uses `{project}/{version}/storybook.zip`; documentation says `{project}/{version}/builds/{buildNumber}/storybook.zip`
+4. **scry-sbcov has the richest metadata**: It's the only tool that knows filepath, componentName, location from AST parsing
+5. **Existing story-capture unification plan**: The `plans/story-capture-feature/` documents already plan to merge storycap + scry-sbcov into a unified `captureStory()` primitive
+
+---
+
+## Recommended Path
+
+| Phase | Approach | Description |
+|-------|----------|-------------|
+| **Short-term** | Option B | scry-node generates basic metadata from `index.json` + existing storycap screenshots |
+| **Medium-term** | Option A | scry-sbcov generates full metadata + screenshots via unified capture service |
+| **Long-term** | Option C | Publish a reusable GitHub Action wrapping the scry-sbcov approach |
+
+**Regardless of option chosen**, the upload-service needs:
+- Queue producer binding and publish code
+- Metadata ZIP upload endpoint (or extension of existing upload)
+- R2 path convention decision
+
+---
+
+## Next Steps
+
+1. Decide which generation option to pursue first (A, B, C, or E)
+2. Implement queue integration in upload-service
+3. Align R2 path conventions across services
+4. Implement chosen generation approach
+5. End-to-end test the full pipeline


### PR DESCRIPTION
Closes #27

Investigate how metadata.json + screenshot ZIPs flow through the Scry platform and identify gaps between what build-processing-service expects and what the upload pipeline currently provides.

Key findings:
- Build-processing expects a ZIP with metadata.json + screenshots
- Upload service only receives Storybook build ZIPs (HTML/JS/CSS)
- No queue integration exists between upload and build-processing
- R2 path conventions differ between services
- Five implementation options analyzed with comparison matrix

Generated with [Claude Code](https://claude.ai/code)